### PR TITLE
directly use yaml-cpp instead of yaml_cpp_vendor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(rsl_drive_sdk)
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(yaml_cpp_vendor REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 add_definitions(-DMELO_MIN_SEVERITY=MELO_SEVERITY_INFO)
 add_definitions(-DMELO_USE_COUT)
@@ -29,10 +29,12 @@ target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 
 ament_target_dependencies(${PROJECT_NAME}
   ethercat_sdk_master
-  yaml_cpp_vendor
+  
 )
 
-
+target_link_libraries(${PROJECT_NAME}
+  yaml-cpp 
+)
 
 
 
@@ -47,7 +49,7 @@ ament_export_libraries(
 
 ament_export_dependencies(
   ethercat_sdk_master
-  yaml_cpp_vendor
+  yaml-cpp
 
 )
 

--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
   <depend>message_logger</depend>
   <depend>ethercat_sdk_master</depend>
-  <depend>yaml_cpp_vendor</depend>
+  <depend>yaml-cpp</depend>
 
 </package>


### PR DESCRIPTION
I had the an linker issue in a downstream package due to the yaml_cpp_vendor package. Directly using the system yaml-cpp seems to solve the issue.

It looks like the the vendor package is explicitly compiled with c++11 which results in an incompatible abi (just a guess not sure). 